### PR TITLE
Update generate metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For more options use `--help` at end.
 
 ![metadata help](docs/generate-metadata--help.gif)
 
-`Note: For the first time use this command will ask for three extra inputs - OSSPOI_DIR: location of besecure-osspoi-datastore in local system, ASSESSMENT_DIR: location of besecure-assessment-datastore, GITHUB_AUTH_TOKEN`
+`Note: For the first time use this command will ask for three extra inputs - ASSETS_DIR: location of besecure-osspoi-datastore in local system, ASSESSMENT_DIR: location of besecure-assessment-datastore, GITHUB_AUTH_TOKEN`
 
 ![metadata first time](docs/generate-metadata-first-time.jpg)
 

--- a/bes_dev_kit/cli.py
+++ b/bes_dev_kit/cli.py
@@ -27,7 +27,7 @@ def write_env_vars_file():
     vars_file_path = f"{vars_dir_path}/bes-dev-kit.json"
     env_vars = {
         "GITHUB_ORG": "Be-Secure",
-        "OSSPOI_DIR": "",
+        "ASSETS_DIR": "",
         "ASSESSMENT_DIR": "",
         "GITHUB_AUTH_TOKEN": ""
     }
@@ -67,6 +67,7 @@ def check_if_value_empty():
     with open(vars_file_path, 'r+', encoding="utf-8") as file_pointer:
         env_vars = json.load(file_pointer)
         for key, value in env_vars.items():
+
             if value == "":
                 new_value = prompt_user(key, value)
                 env_vars[key] = new_value
@@ -99,7 +100,7 @@ def ossp(
     name: str = typer.Option(None, prompt="Enter OSSP name", help="OSSP name"),
     overwrite: bool = typer.Option(False, help="Overwrite the existing entries")
     ):
-    """ Update OSSP-master.json file and add/update version file to osspoi datastore """
+    """ Update project-metadata.json file and add/update version file to osspoi datastore """
     if platform != "linux":
         print("[bold red]BeS-dev-kit is compatible"
               " only with Linux operating systems")

--- a/bes_dev_kit/src/create_ossp_master.py
+++ b/bes_dev_kit/src/create_ossp_master.py
@@ -225,7 +225,8 @@ class OSSPMaster():
                     elif i == "bes_technology_stack":
                         ossp_data[i] = self.write_tech_stack(self.issue_id)
                     elif i == "project_repos":
-                        ossp_data[i] = self.write_project_repos_data(project_data)
+                        if "parent" in project_data:
+                            ossp_data[i] = self.write_project_repos_data(project_data)
                     elif i == "tags":
                         ossp_data[i] = self.write_tags(self.issue_id)
                     elif i == "language":

--- a/bes_dev_kit/src/create_ossp_master.py
+++ b/bes_dev_kit/src/create_ossp_master.py
@@ -172,10 +172,10 @@ class OSSPMaster():
         file_pointer.truncate()
         if overwrite:
             print("[bold red]Alert! [green]Data for " +
-                f"[yellow]{self.name} [green] in OSSP-Master.json has been overwritten")
+                f"[yellow]{self.name} [green] in project-metadata.json has been overwritten")
         else:
             print("[bold red]Alert! [green]Added " +
-                f"[yellow]{self.name} [green]to OSSP-Master.json")
+                f"[yellow]{self.name} [green]to project-metadata.json")
 
 
     def generate_ossp_master(self, overwrite: bool):
@@ -191,15 +191,15 @@ class OSSPMaster():
                   f"{self.name} [green]does not exist")
             sys.exit()
         self.check_issue_related_to_project()
-        osspoi_dir = os.environ['OSSPOI_DIR']
+        osspoi_dir = os.environ['ASSETS_DIR']
         write_flag = True
-        with open(f"{osspoi_dir}/OSSP-Master.json", "r+", encoding="utf-8") as file_pointer:
+        with open(f"{osspoi_dir}/projects/project-metadata.json", "r+", encoding="utf-8") as file_pointer:
             ossp_master_json = json.load(file_pointer)
             if not overwrite:
                 for i in range(len(ossp_master_json["items"])):
                     if ossp_master_json["items"][i]["id"] == self.issue_id:
                         print("[bold red]Alert! [green]Entry for "+str(self.issue_id) +
-                            "-"+self.name+" already present under OSSP-Master.json")
+                            "-"+self.name+" already present under project-metadata.json")
                         write_flag = False
                         break
             if write_flag:

--- a/bes_dev_kit/src/create_version_data.py
+++ b/bes_dev_kit/src/create_version_data.py
@@ -96,7 +96,7 @@ class Version():
         """
             generate version details page in osspoi_datastore
         """
-        osspoi_dir = os.environ['OSSPOI_DIR']
+        osspoi_dir = os.environ['ASSETS_DIR']
         version_data_new = {
             "version": "",
             "release_date": "",
@@ -112,7 +112,7 @@ class Version():
             version_data_new["release_date"] = "Not Available"
         else:
             version_data_new["release_date"] = date
-        path = osspoi_dir+"/version_details/" + \
+        path = osspoi_dir+"/projects/project-version/" + \
             str(self.issue_id) + "-" + self.name + "-" "Versiondetails.json"
         if os.path.exists(path):
             with open(path, "r+", encoding="utf-8") as file_pointer:

--- a/bes_dev_kit/src/generate_report.py
+++ b/bes_dev_kit/src/generate_report.py
@@ -114,12 +114,12 @@ class Report():
         """
             provide versiondetails for version and read from assessment data store
         """
-        osspoi_dir = os.environ['OSSPOI_DIR']
+        osspoi_dir = os.environ['ASSETS_DIR']
         assessment_dir = os.environ['ASSESSMENT_DIR']
         report_file = open(assessment_dir+'/'+self.name+'/'+self.version+'/'+self.report +
                             '/'+self.name + '-' + self.version +
                             '-' + self.report + '-report.json', "r", encoding="utf-8")
-        version_file = open(osspoi_dir+"/version_details/"+str(self.issue_id) +
+        version_file = open(osspoi_dir+"/projects/project-version/"+str(self.issue_id) +
                             "-" + self.name + "-" "Versiondetails.json", "r+", encoding="utf-8")
 
         score_data = json.load(report_file)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -85,13 +85,13 @@ def test_metadata():
     issue_id = "136"
     name = "fastjson"
     version = "version"
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     result = runner.invoke(app, ["generate", "metadata"], input=issue_id+"\n"+name+"\n")
     assert result.exit_code == 0
     version_file = os.path.exists(f'{osspoi}/version_details/{issue_id}-{name}-Versiondetails.json')
-    ossp_master_file = os.path.exists(f'{osspoi}/OSSP-Master.json')
+    ossp_master_file = os.path.exists(f'{osspoi}/projects/project-metadata.json')
     print(ossp_master_file)
-    f = open(f'{osspoi}/OSSP-Master.json')
+    f = open(f'{osspoi}/projects/project-metadata.json')
     ossp_master_data = json.load(f)
     for i in range(len(ossp_master_data["items"])):
         if ossp_master_data["items"][i]["issue_id"] == int(issue_id) and ossp_master_data["items"][i]["name"] == name:
@@ -106,7 +106,7 @@ def test_metadata():
 def test_version_file_not_empty():
     issue_id = "136"
     name = "fastjson"
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     result = runner.invoke(app, ["generate", "metadata"], input=issue_id+"\n"+name+"\n")
     assert result.exit_code == 0
     size = os.path.getsize(f'{osspoi}/version_details/{issue_id}-{name}-Versiondetails.json')
@@ -123,7 +123,7 @@ def test_overwrite():
         "scorecard": "Not Available",
         "cve_details": "Not Available"
     }]
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     result = runner.invoke(app, ["generate", "metadata", "--overwrite"], input=issue_id+"\n"+name+"\n")
     assert result.exit_code == 0
     f = open(f'{osspoi}/version_details/{issue_id}-{name}-Versiondetails.json')
@@ -134,7 +134,7 @@ def test_without_overwrite():
     issue_id = "136"
     name = "fastjson"
     version = "1.2.24"
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     f = open(f"{osspoi}/version_details/{issue_id}-{name}-Versiondetails.json")
     original_version_data = json.load(f)
     for i in range(len(original_version_data)):
@@ -158,10 +158,10 @@ def test_without_overwrite():
 def test_issue_project_mismatch():
     issue_id = 137
     name = "fastjson"
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     result = runner.invoke(app, ["generate", "metadata"], input=str(issue_id)+"\n"+name+"\n")
     assert result.exit_code == 0
-    f = open(f'{osspoi}/OSSP-Master.json')
+    f = open(f'{osspoi}/projects/project-metadata.json')
     ossp_master_json = json.load(f)
     for i in range(len(ossp_master_json["items"])): 
         if ossp_master_json["items"][i]["issue_id"] == issue_id and ossp_master_json["items"][i]["name"] == name:
@@ -178,7 +178,7 @@ def test_version_alpha():
     name = "SYCLomatic-test"
     version = "alpha"
     release_date = "Not Available"
-    osspoi = os.environ['OSSPOI_DIR']
+    osspoi = os.environ['ASSETS_DIR']
     result = runner.invoke(app, ["generate", "metadata"], input=str(issue_id)+"\n"+name+"\n")
     assert result.exit_code == 0
     f = open(f"{osspoi}/version_details/{issue_id}-{name}-Versiondetails.json")

--- a/tests/test_vdnc.py
+++ b/tests/test_vdnc.py
@@ -146,7 +146,7 @@ def test_vdnc_with_invalid_project():
 
 
 def test_vdnc_check_under_OSSPMaster():
-    """check if mentioned project exists under OSSP-master.json file"""
+    """check if mentioned project exists under project-metadata.json file"""
     issue_id = 405
     name = "OpenIDM"
     namespace = "pramit-d"


### PR DESCRIPTION
1. Fixed https://github.com/Be-Secure/BeS-dev-kit/issues/55
**Root cause:** BeS-dev-kit was showing errors while the user tried to generate metadata for Be-Secure original/own projects (like. BLIman, BeS-dev-kit, BeSLighthouse, BeSman, etc). For these types of projects, there are no parent details available in [GitHub API](https://api.github.com/repos/Be-Secure/BLIman). BeS-dev-kit trying to fetch **parent** details at the time of metadata generation. For this reason, the user is getting an error.
**Resolution:** If **parent** is available in the above-mentioned GitHub API, BeS-dev-kit will fetch the data. Otherwise, it will skip the process.
 
2. Added new besecure-asset-store repository https://github.com/Be-Secure/BeS-dev-kit/issues/54
Removed **besecure-osspoi-datastore** and added **besecure-asset-store** repository.

