### PR TITLE
Fixed bug: generate criticality_score

### DIFF
--- a/bes_dev_kit/src/generate_report.py
+++ b/bes_dev_kit/src/generate_report.py
@@ -6,7 +6,6 @@ import csv
 import sys
 import os
 import subprocess
-from distutils.version import LooseVersion
 from urllib.request import urlopen
 from rich import print
 

--- a/bes_dev_kit/src/generate_report.py
+++ b/bes_dev_kit/src/generate_report.py
@@ -39,15 +39,17 @@ class Report():
             create json report for criticality_score, codeql, and scorecard
         """
         if self.report == "criticality_score":
-            token = os.environ['GITHUB_AUTH_TOKEN']
             json_file_path = '/tmp/' + self.name + '-' + self.version + '-' + self.report+'.json'
             command = 'criticality_score -depsdev-disable -format json https://' + url
             command = command + f" > {json_file_path} 2>/dev/null"
             try:
-                res = subprocess.run('go version', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-                print(" return code: ", res.returncode, " stdout: ", res.stdout, " stderr: ",res.stderr)
+                res = subprocess.run('go version',
+                                     shell=True,
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     check=True)
             except:
-                print('[bold green]Please enter root credentials...')
+                print('[bold green]Please enter root password...')
                 os.system('snap install go --classic')
                 
             os.system(f'''go install github.com/ossf/criticality_score/cmd/criticality_score@latest

--- a/bes_dev_kit/src/generate_report.py
+++ b/bes_dev_kit/src/generate_report.py
@@ -10,9 +10,6 @@ from distutils.version import LooseVersion
 from urllib.request import urlopen
 from rich import print
 
-class GoVersionError(Exception):
-    """Base class for other exceptions"""
-    pass
 class Report():
     """
         Create report for scorcard, codeQl, and criticality_score

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ pytest = "^7.3.0"
 requests = "^2.29.0"
 reportlab = "^3.6.8" 
 
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ typer = {extras = ["all"], version = "^0.9.0"}
 pytest = "^7.3.0"
 requests = "^2.29.0"
 reportlab = "^3.6.8"
-criticality-score = "^1.0.8"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.10"
 typer = {extras = ["all"], version = "^0.9.0"}
 pytest = "^7.3.0"
 requests = "^2.29.0"
-reportlab = "^3.6.8"
+reportlab = "^3.6.8" 
 
 
 [build-system]


### PR DESCRIPTION
Fixed https://github.com/Be-Secure/BeS-dev-kit/issues/57

**Root cause:** Due to some internal issues of the criticality_score package users were getting errors in BeS-dev-kit.
**Resolution:** Previously BeS-dev-kit was installing criticality_score through pip. The mentioned criticality_score package has been discontinued. So **[ossf](https://github.com/ossf/criticality_score)** will not provide support for the version we are using. Currently, **[ossf](https://github.com/ossf/criticality_score)** suggesting to install the package using Go. So changed the installation procedure in BeS-dev-kit.